### PR TITLE
Skip Serialising Option::None so that Mongo doesn't have Null's

### DIFF
--- a/server/src/models/user_model.rs
+++ b/server/src/models/user_model.rs
@@ -33,6 +33,7 @@ pub struct User {
   pub income: f64,
   // recurrings: Vec<ObjectId>,
   // snapshots: Vec<ObjectId>,
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub accounts: Option<Vec<PlaidItem>>,
 }
 


### PR DESCRIPTION
necessary so that we dont $push to null